### PR TITLE
Adding keydrive teleop

### DIFF
--- a/launch/cora_keydrive.launch
+++ b/launch/cora_keydrive.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="max_angle" default="$(eval pi/2)"/>
+  <arg name="thrust_config" default="H"/>
+  <arg name="namespace" default="cora1/cora"/>
+
+  <!-- Keyboard teleop -->
+  <node pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" name="teleop_twist_keyboard" output="screen">
+  <remap from="cmd_vel" to="/cora1/cora/cmd_vel"/>
+  </node>
+
+</launch>


### PR DESCRIPTION
To test:
git fetch
git checkout kd/teleop

roslaunch mrc_examples marina_1x.launch

In a new tab:
roslaunch ay22_gdk cora_keydrive.launch

You should be able to drive the boat around similar to hw4. The boat responded faster by increasing the max speed using 'q'